### PR TITLE
Give this line a single input cell to avoid output be coverd 

### DIFF
--- a/ch06.ipynb
+++ b/ch06.ipynb
@@ -99,7 +99,17 @@
    },
    "outputs": [],
    "source": [
-    "pd.read_csv('ch06/ex2.csv', header=None)\n",
+    "pd.read_csv('ch06/ex2.csv', header=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
     "pd.read_csv('ch06/ex2.csv', names=['a', 'b', 'c', 'd', 'message'])"
    ]
   },


### PR DESCRIPTION
Put "pd.read_csv('ch06/ex2.csv', names=['a', 'b', 'c', 'd', 'message'])" in a new input cell below to avoid output be covered
