### PR TITLE
Update ch05.ipynb

### DIFF
--- a/ch05.ipynb
+++ b/ch05.ipynb
@@ -1538,7 +1538,7 @@
    "outputs": [],
    "source": [
     "obj = Series([4, 7, -3, 2])\n",
-    "obj.order()"
+    "obj.sort_values()"
    ]
   },
   {
@@ -1550,7 +1550,7 @@
    "outputs": [],
    "source": [
     "obj = Series([4, np.nan, 7, np.nan, -3, 2])\n",
-    "obj.order()"
+    "obj.sort_values()"
    ]
   },
   {


### PR DESCRIPTION
order() is deprecated use sort_values()
