### PR TITLE
Update ch05.ipynb

### DIFF
--- a/ch05.ipynb
+++ b/ch05.ipynb
@@ -1573,7 +1573,7 @@
    },
    "outputs": [],
    "source": [
-    "frame.sort_index(by='b')"
+    "frame.sort_values(by='b')"
    ]
   },
   {
@@ -1584,7 +1584,7 @@
    },
    "outputs": [],
    "source": [
-    "frame.sort_index(by=['a', 'b'])"
+    "frame.sort_values(by=['a', 'b'])"
    ]
   },
   {


### PR DESCRIPTION
by argument to sort_index is deprecated use sort_values and you are indeed sorting values not index right?
