### PR TITLE
Issue #60: change Series.order() to Series.sort_value()

### DIFF
--- a/notebooks/ch05.ipynb
+++ b/notebooks/ch05.ipynb
@@ -1538,7 +1538,7 @@
    "outputs": [],
    "source": [
     "obj = Series([4, 7, -3, 2])\n",
-    "obj.order()"
+    "obj.sort_value() # Series.order has been deprecated since v0.17"
    ]
   },
   {
@@ -1550,7 +1550,7 @@
    "outputs": [],
    "source": [
     "obj = Series([4, np.nan, 7, np.nan, -3, 2])\n",
-    "obj.order()"
+    "obj.sort_value() # Series.order has been deprecated since v0.17"
    ]
   },
   {


### PR DESCRIPTION
Dear pydata-book maintainer,

Here is a PR for issue #60. In Sorting and ranking section of Chapter 5, Series.order function is used. Since it has been deprecated from v0.17, I change `order` to `sort_value`:

``` python
obj = Series([4, 7, -3, 2])
obj.sort_value() # Series.order has been deprecated from v0.17
obj = Series([4, np.nan, 7, np.nan, -3, 2])
obj.sort_value() # Series.order has been deprecated from v0.17
```

Best regards,
Jing Qin