### PR TITLE
Add a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+numpy==1.13.3
+pandas==0.21.0
+matplotlib==2.1.0
+lxml==4.1.0
+seaborn==0.8.1
+statsmodels==0.8.0
+scipy==1.0.0
+patsy==0.4.1
+scikit-learn==0.19.1
+beautifulsoup4==4.6.0


### PR DESCRIPTION
A set of package versions that (seem to) work together. This makes it easier for people to install all dependencies in one go and let's you run the notebooks on binder: https://mybinder.org/v2/gh/betatim/pydata-book/requirements