### PR TITLE
fixes to ch06 to make it run without error; specifically:

### DIFF
--- a/ch06.ipynb
+++ b/ch06.ipynb
@@ -486,8 +486,7 @@
    },
    "outputs": [],
    "source": [
-    "with open('examples/ex7.csv') as f:\n",
-    "    lines = list(csv.reader(f))"
+    "lines = list(csv.reader(open('examples/ex7.csv')))"
    ]
   },
   {
@@ -518,11 +517,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "deletable": true,
     "editable": true
    },
+   "outputs": [],
    "source": [
     "class my_dialect(csv.Dialect):\n",
     "    lineterminator = '\\n'\n",
@@ -532,31 +533,37 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "deletable": true,
     "editable": true
    },
+   "outputs": [],
    "source": [
     "reader = csv.reader(f, dialect=my_dialect)"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "deletable": true,
     "editable": true
    },
+   "outputs": [],
    "source": [
     "reader = csv.reader(f, delimiter='|')"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "deletable": true,
     "editable": true
    },
+   "outputs": [],
    "source": [
     "with open('mydata.csv', 'w') as f:\n",
     "    writer = csv.writer(f, dialect=my_dialect)\n",
@@ -986,6 +993,7 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
     "os.remove('mydata.h5')"
    ]
   },


### PR DESCRIPTION
import `os` module required to `os.remove`  hdf5 file
change some cells from md to code
don't use `with` to open examples/ex7.csv as it leaves filehandle `f` in closed state and unavailable for later cell that references it as an iterator