### PR TITLE
ch11: duplicate cell fixed

### DIFF
--- a/ch11.ipynb
+++ b/ch11.ipynb
@@ -1494,7 +1494,7 @@
    },
    "outputs": [],
    "source": [
-    "ts.resample('5min', closed='right').sum()"
+    "ts.resample('5min').sum()"
    ]
   },
   {


### PR DESCRIPTION
There were two identical cells for downsampling. I adjusted the first one so that there is a proper example for the default bin edge behavior.