### PR TITLE
fix ch03.ipynb example mixing up first/last names

### DIFF
--- a/ch03.ipynb
+++ b/ch03.ipynb
@@ -787,7 +787,7 @@
    "outputs": [],
    "source": [
     "pitchers = [('Nolan', 'Ryan'), ('Roger', 'Clemens'),\n",
-    "            ('Schilling', 'Curt')]\n",
+    "            ('Curt', 'Schilling')]\n",
     "first_names, last_names = zip(*pitchers)\n",
     "first_names\n",
     "last_names"


### PR DESCRIPTION
Curt is the first name, Schilling the last. Readers who know this may be confused by the example as presented.