### PR TITLE
Add Open in Kaggle badge

### DIFF
--- a/ch02.ipynb
+++ b/ch02.ipynb
@@ -7,7 +7,9 @@
     "editable": true
    },
    "source": [
-    "# Python Language Basics, IPython, and Jupyter Notebooks"
+    "# Python Language Basics, IPython, and Jupyter Notebooks",
+    "\n",
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/wesm/pydata-book/blob/2nd-edition/ch02.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
    ]
   },
   {


### PR DESCRIPTION
This is an example of what adding a Kaggle Badge (that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480) could look like.

If it makes sense I can submit a further PR adding it to the other notebooks in this repository.