### PR TITLE
Remove unneeded call to `list()`

### DIFF
--- a/ch03.ipynb
+++ b/ch03.ipynb
@@ -1711,7 +1711,7 @@
    },
    "outputs": [],
    "source": [
-    "strings.sort(key=lambda x: len(set(list(x))))\n",
+    "strings.sort(key=lambda x: len(set(x)))\n",
     "strings"
    ]
   },


### PR DESCRIPTION
The example lambda function works without the `list()` call.