### PR TITLE
Ch04 update np.random

### DIFF
--- a/ch04.ipynb
+++ b/ch04.ipynb
@@ -1159,7 +1159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rng = np.random.default_rng(seed=1234)",
+    "rng = np.random.default_rng(seed=1234)\n",
     "rng.randn(10)"
    ]
   },
@@ -1231,10 +1231,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Alternatively"
+    "# Alternatively\n",
     "nsteps = 1000\n",
     "draws = rng.integers(low=0, high=2, size=nsteps)\n",
-    "steps = draws * 2 - 1\n  # steps is either -1 or +1",
+    "steps = draws * 2 - 1\n  # steps is either -1 or +1\n",
     "walk = steps.cumsum()"
    ]
   },

--- a/ch04.ipynb
+++ b/ch04.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# NumPy Basics: Arrays and Vectorized Computation"
    ]
@@ -13,11 +10,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -30,11 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -45,11 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%time for _ in range(10): my_arr2 = my_arr * 2\n",
@@ -58,10 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## The NumPy ndarray: A Multidimensional Array Object"
    ]
@@ -69,11 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -85,11 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data * 10\n",
@@ -99,11 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data.shape\n",
@@ -112,10 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Creating ndarrays"
    ]
@@ -123,11 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data1 = [6, 7.5, 8, 0, 1]\n",
@@ -138,11 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data2 = [[1, 2, 3, 4], [5, 6, 7, 8]]\n",
@@ -153,11 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2.ndim\n",
@@ -167,11 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr1.dtype\n",
@@ -181,11 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.zeros(10)\n",
@@ -196,11 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.arange(15)"
@@ -208,10 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Data Types for ndarrays"
    ]
@@ -219,11 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr1 = np.array([1, 2, 3], dtype=np.float64)\n",
@@ -235,11 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.array([1, 2, 3, 4, 5])\n",
@@ -251,11 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.array([3.7, -1.2, -2.6, 0.5, 12.9, 10.1])\n",
@@ -266,11 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "numeric_strings = np.array(['1.25', '-9.6', '42'], dtype=np.string_)\n",
@@ -280,11 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "int_array = np.arange(10)\n",
@@ -295,11 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "empty_uint32 = np.empty(8, dtype='u4')\n",
@@ -308,10 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Arithmetic with NumPy Arrays"
    ]
@@ -319,11 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.array([[1., 2., 3.], [4., 5., 6.]])\n",
@@ -335,11 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "1 / arr\n",
@@ -349,11 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2 = np.array([[0., 4., 1.], [7., 2., 12.]])\n",
@@ -363,10 +264,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Basic Indexing and Slicing"
    ]
@@ -374,11 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.arange(10)\n",
@@ -392,11 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr_slice = arr[5:8]\n",
@@ -406,11 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr_slice[1] = 12345\n",
@@ -420,11 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr_slice[:] = 64\n",
@@ -434,11 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])\n",
@@ -448,11 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d[0][2]\n",
@@ -462,11 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr3d = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]])\n",
@@ -476,11 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr3d[0]"
@@ -489,11 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "old_values = arr3d[0].copy()\n",
@@ -506,11 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr3d[1, 0]"
@@ -519,11 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x = arr3d[1]\n",
@@ -533,10 +387,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "#### Indexing with slices"
    ]
@@ -544,11 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr\n",
@@ -558,11 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d\n",
@@ -572,11 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d[:2, 1:]"
@@ -585,11 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d[1, :2]"
@@ -598,11 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d[:2, 2]"
@@ -611,11 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d[:, :1]"
@@ -624,11 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr2d[:2, 1:] = 0\n",
@@ -637,10 +460,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Boolean Indexing"
    ]
@@ -648,11 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "names = np.array(['Bob', 'Joe', 'Will', 'Bob', 'Will', 'Joe', 'Joe'])\n",
@@ -664,11 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "names == 'Bob'"
@@ -677,11 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data[names == 'Bob']"
@@ -690,11 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data[names == 'Bob', 2:]\n",
@@ -704,11 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "names != 'Bob'\n",
@@ -718,11 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cond = names == 'Bob'\n",
@@ -732,11 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mask = (names == 'Bob') | (names == 'Will')\n",
@@ -747,11 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data[data < 0] = 0\n",
@@ -761,11 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data[names != 'Joe'] = 7\n",
@@ -774,10 +558,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Fancy Indexing"
    ]
@@ -785,11 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.empty((8, 4))\n",
@@ -801,11 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr[[4, 3, 0, 6]]"
@@ -814,11 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr[[-3, -5, -7]]"
@@ -827,11 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.arange(32).reshape((8, 4))\n",
@@ -842,11 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr[[1, 5, 7, 2]][:, [0, 3, 1, 2]]"
@@ -854,10 +615,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Transposing Arrays and Swapping Axes"
    ]
@@ -865,11 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.arange(15).reshape((3, 5))\n",
@@ -880,11 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.random.randn(6, 3)\n",
@@ -895,11 +645,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.arange(16).reshape((2, 2, 4))\n",
@@ -910,11 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr\n",
@@ -923,10 +665,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Universal Functions: Fast Element-Wise Array Functions"
    ]
@@ -934,11 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.arange(10)\n",
@@ -950,11 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x = np.random.randn(8)\n",
@@ -967,11 +698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.random.randn(7) * 5\n",
@@ -984,11 +711,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr\n",
@@ -999,10 +722,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Array-Oriented Programming with Arrays"
    ]
@@ -1010,11 +730,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "points = np.arange(-5, 5, 0.01) # 1000 equally spaced points\n",
@@ -1025,11 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "z = np.sqrt(xs ** 2 + ys ** 2)\n",
@@ -1039,11 +751,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -1054,11 +762,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.draw()"
@@ -1067,11 +771,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.close('all')"
@@ -1079,10 +779,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Expressing Conditional Logic as Array Operations"
    ]
@@ -1090,11 +787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "xarr = np.array([1.1, 1.2, 1.3, 1.4, 1.5])\n",
@@ -1105,11 +798,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result = [(x if c else y)\n",
@@ -1120,11 +809,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result = np.where(cond, xarr, yarr)\n",
@@ -1134,11 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.random.randn(4, 4)\n",
@@ -1150,11 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.where(arr > 0, 2, arr) # set only positive values to 2"
@@ -1162,10 +839,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Mathematical and Statistical Methods"
    ]
@@ -1173,11 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.random.randn(5, 4)\n",
@@ -1190,11 +860,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr.mean(axis=1)\n",
@@ -1204,11 +870,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.array([0, 1, 2, 3, 4, 5, 6, 7])\n",
@@ -1218,11 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])\n",
@@ -1233,10 +891,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Methods for Boolean Arrays"
    ]
@@ -1244,11 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.random.randn(100)\n",
@@ -1258,11 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bools = np.array([False, False, True, False])\n",
@@ -1272,10 +919,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Sorting"
    ]
@@ -1283,11 +927,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.random.randn(6)\n",
@@ -1299,11 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.random.randn(5, 3)\n",
@@ -1315,11 +951,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "large_arr = np.random.randn(1000)\n",
@@ -1329,10 +961,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Unique and Other Set Logic"
    ]
@@ -1340,11 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "names = np.array(['Bob', 'Joe', 'Will', 'Bob', 'Will', 'Joe', 'Joe'])\n",
@@ -1356,11 +981,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sorted(set(names))"
@@ -1369,11 +990,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "values = np.array([6, 0, 0, 3, 2, 5, 6])\n",
@@ -1382,10 +999,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## File Input and Output with Arrays"
    ]
@@ -1393,11 +1007,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arr = np.arange(10)\n",
@@ -1407,11 +1017,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.load('some_array.npy')"
@@ -1420,11 +1026,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.savez('array_archive.npz', a=arr, b=arr)"
@@ -1433,11 +1035,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "arch = np.load('array_archive.npz')\n",
@@ -1447,11 +1045,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.savez_compressed('arrays_compressed.npz', a=arr, b=arr)"
@@ -1460,11 +1054,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!rm some_array.npy\n",
@@ -1474,10 +1064,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Linear Algebra"
    ]
@@ -1485,11 +1072,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x = np.array([[1., 2., 3.], [4., 5., 6.]])\n",
@@ -1502,11 +1085,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.dot(x, y)"
@@ -1515,11 +1094,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.dot(x, np.ones(3))"
@@ -1528,11 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x @ np.ones(3)"
@@ -1541,11 +1112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from numpy.linalg import inv, qr\n",
@@ -1559,10 +1126,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Pseudorandom Number Generation"
    ]
@@ -1570,11 +1134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "samples = np.random.normal(size=(4, 4))\n",
@@ -1584,11 +1144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from random import normalvariate\n",
@@ -1600,11 +1156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.random.seed(1234)"
@@ -1613,11 +1165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "rng = np.random.RandomState(1234)\n",
@@ -1626,10 +1174,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Example: Random Walks"
    ]
@@ -1637,11 +1182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import random\n",
@@ -1657,11 +1198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.figure()"
@@ -1670,11 +1207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.plot(walk[:100])"
@@ -1683,11 +1216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.random.seed(12345)"
@@ -1696,11 +1225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nsteps = 1000\n",
@@ -1712,11 +1237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "walk.min()\n",
@@ -1726,11 +1247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "(np.abs(walk) >= 10).argmax()"
@@ -1738,10 +1255,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Simulating Many Random Walks at Once"
    ]
@@ -1749,11 +1263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "nwalks = 5000\n",
@@ -1767,11 +1277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "walks.max()\n",
@@ -1781,11 +1287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hits30 = (np.abs(walks) >= 30).any(1)\n",
@@ -1796,11 +1298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "crossing_times = (np.abs(walks[hits30]) >= 30).argmax(1)\n",
@@ -1810,11 +1308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "steps = np.random.normal(loc=0, scale=0.25,\n",
@@ -1823,10 +1317,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Conclusion"
    ]
@@ -1834,7 +1325,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1848,9 +1339,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.10.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ch04.ipynb
+++ b/ch04.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "np.random.seed(12345)\n",
+    "rng = np.random.default_rng(seed=12345)\n",
     "import matplotlib.pyplot as plt\n",
     "plt.rc('figure', figsize=(10, 6))\n",
     "np.set_printoptions(precision=4, suppress=True)"
@@ -56,7 +56,7 @@
    "source": [
     "import numpy as np\n",
     "# Generate some random data\n",
-    "data = np.random.randn(2, 3)\n",
+    "data = rng.standard_normal((2,3))\n",
     "data"
    ]
   },
@@ -472,7 +472,7 @@
    "outputs": [],
    "source": [
     "names = np.array(['Bob', 'Joe', 'Will', 'Bob', 'Will', 'Joe', 'Joe'])\n",
-    "data = np.random.randn(7, 4)\n",
+    "data = rng.standard_normal((7,4))\n",
     "names\n",
     "data"
    ]
@@ -637,7 +637,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.random.randn(6, 3)\n",
+    "arr = rng.standard_normal((6,3))\n",
     "arr\n",
     "np.dot(arr.T, arr)"
    ]
@@ -688,8 +688,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = np.random.randn(8)\n",
-    "y = np.random.randn(8)\n",
+    "x = rng.standard_normal(8)\n",
+    "y = rng.standard_normal(8)\n",
     "x\n",
     "y\n",
     "np.maximum(x, y)"
@@ -701,7 +701,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.random.randn(7) * 5\n",
+    "arr = rng.standard_normal(7) * 5\n",
     "arr\n",
     "remainder, whole_part = np.modf(arr)\n",
     "remainder\n",
@@ -822,7 +822,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.random.randn(4, 4)\n",
+    "arr = rng.standard_normal((4, 4))\n",
     "arr\n",
     "arr > 0\n",
     "np.where(arr > 0, 2, -2)"
@@ -850,7 +850,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.random.randn(5, 4)\n",
+    "arr = rng.standard_normal((5, 4))\n",
     "arr\n",
     "arr.mean()\n",
     "np.mean(arr)\n",
@@ -902,7 +902,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.random.randn(100)\n",
+    "arr = rng.standard_normal(100)\n",
     "(arr > 0).sum() # Number of positive values"
    ]
   },
@@ -930,7 +930,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.random.randn(6)\n",
+    "arr = rng.standard_normal(6)\n",
     "arr\n",
     "arr.sort()\n",
     "arr"
@@ -942,7 +942,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.random.randn(5, 3)\n",
+    "arr = rng.standard_normal((5,3))\n",
     "arr\n",
     "arr.sort(1)\n",
     "arr"
@@ -954,7 +954,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "large_arr = np.random.randn(1000)\n",
+    "large_arr = rng.standard_normal(1000)\n",
     "large_arr.sort()\n",
     "large_arr[int(0.05 * len(large_arr))] # 5% quantile"
    ]
@@ -1116,7 +1116,7 @@
    "outputs": [],
    "source": [
     "from numpy.linalg import inv, qr\n",
-    "X = np.random.randn(5, 5)\n",
+    "X = rng.standard_normal((5, 5))\n",
     "mat = X.T.dot(X)\n",
     "inv(mat)\n",
     "mat.dot(inv(mat))\n",
@@ -1137,7 +1137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "samples = np.random.normal(size=(4, 4))\n",
+    "samples= rng.normal(size=(4, 4))\n",
     "samples"
    ]
   },
@@ -1150,7 +1150,7 @@
     "from random import normalvariate\n",
     "N = 1000000\n",
     "%timeit samples = [normalvariate(0, 1) for _ in range(N)]\n",
-    "%timeit np.random.normal(size=N)"
+    "%timeit rng.normal(size=N)"
    ]
   },
   {
@@ -1159,16 +1159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(1234)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rng = np.random.RandomState(1234)\n",
+    "rng = np.random.default_rng(seed=1234)",
     "rng.randn(10)"
    ]
   },
@@ -1190,7 +1181,7 @@
     "walk = [position]\n",
     "steps = 1000\n",
     "for i in range(steps):\n",
-    "    step = 1 if random.randint(0, 1) else -1\n",
+    "    step = 1 if rng.integers(low=0, high=2) else -1\n",
     "    position += step\n",
     "    walk.append(position)"
    ]
@@ -1219,7 +1210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(12345)"
+    "rng = np.random.default_rng(seed=12345)"
    ]
   },
   {
@@ -1229,8 +1220,21 @@
    "outputs": [],
    "source": [
     "nsteps = 1000\n",
-    "draws = np.random.randint(0, 2, size=nsteps)\n",
+    "draws = rng.integers(low=0, high=2, size=nsteps)\n",
     "steps = np.where(draws > 0, 1, -1)\n",
+    "walk = steps.cumsum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Alternatively"
+    "nsteps = 1000\n",
+    "draws = rng.integers(low=0, high=2, size=nsteps)\n",
+    "steps = draws * 2 - 1\n  # steps is either -1 or +1",
     "walk = steps.cumsum()"
    ]
   },
@@ -1268,7 +1272,7 @@
    "source": [
     "nwalks = 5000\n",
     "nsteps = 1000\n",
-    "draws = np.random.randint(0, 2, size=(nwalks, nsteps)) # 0 or 1\n",
+    "draws = rng.integers(low=0, high=2, size=(nwalks, nsteps)) # 0 or 1\n",
     "steps = np.where(draws > 0, 1, -1)\n",
     "walks = steps.cumsum(1)\n",
     "walks"
@@ -1311,8 +1315,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "steps = np.random.normal(loc=0, scale=0.25,\n",
-    "                         size=(nwalks, nsteps))"
+    "steps = rng.normal(loc=0, scale=0.25,\n",
+    "                   size=(nwalks, nsteps))"
    ]
   },
   {


### PR DESCRIPTION
 Replace old-style numpy.random calls with new generator approach
    
Numpy has moved to a new paradigm for generating random numbers (see: https://numpy.org/doc/stable/reference/random/index.html#random-quick-start)
    
This PR replaces the random.randint, random.randn etc with rng.integers and rng.standard_normal etc.

These changes will require changes to the book text in places.
