### PR TITLE
added and fixed demean_axis in  appa

### DIFF
--- a/appa.ipynb
+++ b/appa.ipynb
@@ -389,6 +389,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def demean_axis(arr, axis=0):\n",
+    "    means = arr.mean(axis)\n",
+    "\n",
+    "    # This generalizes things like [:, :, np.newaxis] to N dimensions\n",
+    "    indexer = [slice(None)] * arr.ndim\n",
+    "    indexer[axis] = np.newaxis\n",
+    "    #Tuple is added in the next line to avoid non-tuple sequence for multidimensional indexing error\n",
+    "    return arr - means[tuple(indexer)]"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 36,
    "metadata": {},
    "outputs": [],
@@ -939,7 +955,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.10.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I found the code in appa.ipynb don't have function `demean_axis` in Appendices A,  so I added it. 
When I used numpy==1.23.0 to run `demean_axis`, an `IndexError` is raised.
```python
[<ipython-input-1-037e683df74f>](https://localhost:8080/#) in demean_axis(arr, axis)
      6     indexer = [slice(None)] * arr.ndim
      7     indexer[axis] = np.newaxis
----> 8     return arr - means[indexer]

IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```
When using numpy==1.22.4 or lower, the code can run successfully but a future warning will be displayed.

>FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.


To fix this error, I added tuple in the last line of `demean_axis`. By using tuple as index, this error is fixed and the new version is compatible with older numpy versions.